### PR TITLE
[Feature/license] 자격증 마이페이지 수정, 자격증 기반 일자리 기능 구현

### DIFF
--- a/app/src/main/java/com/example/client/MainActivity.kt
+++ b/app/src/main/java/com/example/client/MainActivity.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.client.data.api.RetrofitClient
 import com.example.client.data.model.viewmodel.JobOnBoardingViewModel
 import com.example.client.data.model.viewmodel.JobOnBoardingViewModelFactory
+import com.example.client.data.model.viewmodel.JobPostLicenseViewModel
+import com.example.client.data.model.viewmodel.JobPostLicenseViewModelFactory
 import com.example.client.data.model.viewmodel.JobPostViewModel
 import com.example.client.data.model.viewmodel.JobPostViewModelFactory
 import com.example.client.data.repository.MainOnBoardingRepository
@@ -24,6 +26,7 @@ import com.example.client.data.model.viewmodel.mypage.EditProfileViewModel
 import com.example.client.data.model.viewmodel.mypage.EditProfileViewModelFactory
 import com.example.client.data.model.viewmodel.mypage.EditRegionViewModel
 import com.example.client.data.model.viewmodel.mypage.EditRegionViewModelFactory
+import com.example.client.data.repository.JobPostLicenseRepository
 import com.example.client.data.repository.JobPostRepository
 import com.example.client.data.repository.MyPageRepository
 import com.example.client.data.repository.mypage.EditInterestedRepository
@@ -41,6 +44,7 @@ class MainActivity : ComponentActivity() {
         val repositories = AppRepositories(
             mainOnBoardingRepository = MainOnBoardingRepository(apiService),
             jobPostRepository = JobPostRepository(apiService),
+            jobPostLicenseRepository = JobPostLicenseRepository(apiService),
             jobOnBoardingRepository = JobOnBoardingRepository(apiService),
             myPageRepository = MyPageRepository(apiService),
             editInterestedRepository = EditInterestedRepository(apiService),
@@ -60,6 +64,8 @@ class MainActivity : ComponentActivity() {
                 this,
                 JobPostViewModelFactory(repositories.jobPostRepository)
             ).get(JobPostViewModel::class.java),
+            jobPostLicenseViewModel = ViewModelProvider(this, JobPostLicenseViewModelFactory(repositories.jobPostLicenseRepository)
+            ).get(JobPostLicenseViewModel::class.java),
             jobOnBoardingViewModel = ViewModelProvider(
                 this,
                 JobOnBoardingViewModelFactory(repositories.jobOnBoardingRepository)
@@ -93,6 +99,7 @@ class MainActivity : ComponentActivity() {
 data class AppRepositories(
     val mainOnBoardingRepository: MainOnBoardingRepository,
     val jobPostRepository: JobPostRepository,
+    val jobPostLicenseRepository: JobPostLicenseRepository,
     val jobOnBoardingRepository: JobOnBoardingRepository,
     val myPageRepository: MyPageRepository,
     val editInterestedRepository: EditInterestedRepository,
@@ -105,6 +112,7 @@ data class AppRepositories(
 data class AppViewModels(
     val mainOnBoardingViewModel: MainOnBoardingViewModel,
     val jobPostViewModel: JobPostViewModel,
+    val jobPostLicenseViewModel: JobPostLicenseViewModel,
     val jobOnBoardingViewModel: JobOnBoardingViewModel,
     val sharedCertificationViewModel: SharedCertificationViewModel,
     val myPageViewModel: MyPageViewModel,

--- a/app/src/main/java/com/example/client/MainActivity.kt
+++ b/app/src/main/java/com/example/client/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.ViewModelProvider
 import com.example.client.data.api.RetrofitClient
+import com.example.client.data.model.request.mypage.EditLicenseRequest
 import com.example.client.data.model.viewmodel.JobOnBoardingViewModel
 import com.example.client.data.model.viewmodel.JobOnBoardingViewModelFactory
 import com.example.client.data.model.viewmodel.JobPostLicenseViewModel
@@ -22,6 +23,8 @@ import com.example.client.data.model.viewmodel.MyPageViewModel
 import com.example.client.data.model.viewmodel.MyPageViewModelFactory
 import com.example.client.data.model.viewmodel.mypage.EditInterestedViewModel
 import com.example.client.data.model.viewmodel.mypage.EditInterestedViewModelFactory
+import com.example.client.data.model.viewmodel.mypage.EditLicenseViewModel
+import com.example.client.data.model.viewmodel.mypage.EditLicenseViewModelFactory
 import com.example.client.data.model.viewmodel.mypage.EditProfileViewModel
 import com.example.client.data.model.viewmodel.mypage.EditProfileViewModelFactory
 import com.example.client.data.model.viewmodel.mypage.EditRegionViewModel
@@ -30,6 +33,7 @@ import com.example.client.data.repository.JobPostLicenseRepository
 import com.example.client.data.repository.JobPostRepository
 import com.example.client.data.repository.MyPageRepository
 import com.example.client.data.repository.mypage.EditInterestedRepository
+import com.example.client.data.repository.mypage.EditLicenseRepository
 import com.example.client.data.repository.mypage.EditProfileRepository
 import com.example.client.data.repository.mypage.EditRegionRepository
 
@@ -50,6 +54,7 @@ class MainActivity : ComponentActivity() {
             editInterestedRepository = EditInterestedRepository(apiService),
             editRegionRepository = EditRegionRepository(apiService),
             editProfileRepository = EditProfileRepository(apiService),
+            editLicenseRepository = EditLicenseRepository(apiService)
             // 필요한 다른 repository 추가
         )
 
@@ -86,6 +91,10 @@ class MainActivity : ComponentActivity() {
             editProfileViewModel = ViewModelProvider(this,
                 EditProfileViewModelFactory(repositories.editProfileRepository)
             ).get(EditProfileViewModel::class.java),
+            editLicenseViewModel = ViewModelProvider(this,
+                EditLicenseViewModelFactory(repositories.editLicenseRepository)
+            ).get(EditLicenseViewModel::class.java)
+
             // 필요한 다른 viewModel 추가
         )
 
@@ -104,7 +113,8 @@ data class AppRepositories(
     val myPageRepository: MyPageRepository,
     val editInterestedRepository: EditInterestedRepository,
     val editRegionRepository: EditRegionRepository,
-    val editProfileRepository: EditProfileRepository
+    val editProfileRepository: EditProfileRepository,
+    val editLicenseRepository: EditLicenseRepository
     // 필요한 다른 repository 추가
 )
 
@@ -119,5 +129,6 @@ data class AppViewModels(
     val editInterestedViewModel: EditInterestedViewModel,
     val editRegionViewModel: EditRegionViewModel,
     val editProfileViewModel: EditProfileViewModel,
+    val editLicenseViewModel: EditLicenseViewModel
     // 필요한 다른 viewModel 추가
 )

--- a/app/src/main/java/com/example/client/component/job/CertificateButtonComponent.kt
+++ b/app/src/main/java/com/example/client/component/job/CertificateButtonComponent.kt
@@ -48,13 +48,17 @@ fun CertificateButtonComponent(
                 text = license.seriesnm,
                 color = Color(0xFFDCF5B5),
                 fontSize = 16.sp,
+                minLines = 1,
+                maxLines = 1,
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = license.jmfldnm,
                 color = Color(0xFFFFFBDC),
-                fontSize = 24.sp,
+                fontSize = 21.sp,
+                minLines = 1,
+                maxLines = 1,
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/example/client/component/job/CertificateButtonComponent.kt
+++ b/app/src/main/java/com/example/client/component/job/CertificateButtonComponent.kt
@@ -16,12 +16,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.client.R
+import com.example.client.data.model.response.LicensesGetResponse
 
 @Composable
 fun CertificateButtonComponent(
-    certificateDepartment: String,
-    certificateName: String,
-    date: String,
+    license: LicensesGetResponse,
     onClick: () -> Unit
 ) {
     var isOverlayVisible by remember { mutableStateOf(false) }
@@ -46,14 +45,14 @@ fun CertificateButtonComponent(
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = certificateDepartment,
+                text = license.seriesnm,
                 color = Color(0xFFDCF5B5),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = certificateName,
+                text = license.jmfldnm,
                 color = Color(0xFFFFFBDC),
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold
@@ -68,12 +67,14 @@ fun CertificateButtonComponent(
                     modifier = Modifier.padding(end = 8.dp)
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = date,
-                    color = Color.White,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold
-                )
+                license.expirationDate?.let {
+                    Text(
+                        text = it,
+                        color = Color.White,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/client/data/api/ApiService.kt
+++ b/app/src/main/java/com/example/client/data/api/ApiService.kt
@@ -5,6 +5,7 @@ import com.example.client.data.model.request.KakaoLoginRequest
 import com.example.client.data.model.request.MainOnBoardingRequest
 import com.example.client.data.model.response.LicensesGetResponse
 import com.example.client.data.model.request.mypage.EditInterestedRequest
+import com.example.client.data.model.request.mypage.EditLicenseRequest
 import com.example.client.data.model.request.mypage.EditProfileRequest
 import com.example.client.data.model.request.mypage.EditRegionRequest
 import com.example.client.data.model.response.JobPostResponse
@@ -56,7 +57,8 @@ interface ApiService {
     @PATCH("users/mypage/interests") //관심분야 수정
     suspend fun setUserInterests(@Body request: EditInterestedRequest): Response<Void>
 
-    //자격증 수정 추가
+    @PATCH("users/mypage/licenses") //자격증 수정
+    suspend fun setUserLicenses(@Body request: EditLicenseRequest): Response<Void>
 
     /** 커뮤니티 */
     @GET("community/posts") //커뮤니티 더미데이터 불러오기

--- a/app/src/main/java/com/example/client/data/api/ApiService.kt
+++ b/app/src/main/java/com/example/client/data/api/ApiService.kt
@@ -1,7 +1,6 @@
 package com.example.client.data.api
 
 import com.example.client.data.model.request.JobOnBoardingRequest
-import com.example.client.data.model.request.JobPostLicenseRequest
 import com.example.client.data.model.request.KakaoLoginRequest
 import com.example.client.data.model.request.MainOnBoardingRequest
 import com.example.client.data.model.response.LicensesGetResponse
@@ -16,6 +15,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface ApiService {
     /** 카카오 로그인 */
@@ -37,7 +37,7 @@ interface ApiService {
     suspend fun searchJob(): Response<Void>
 
     @GET("jobs/posts/licenses") //사용자가 클릭한 자격증 이름으로 request
-    suspend fun getJobLicense(@Body request: JobPostLicenseRequest): Response<List<JobPostResponse>>
+    suspend fun getJobLicense(@Query("jmfldnm") jmfldnm: String): Response<List<JobPostResponse>>
 
     /** 자격증 리스트 소환 */
     @GET("licenses")

--- a/app/src/main/java/com/example/client/data/api/ApiService.kt
+++ b/app/src/main/java/com/example/client/data/api/ApiService.kt
@@ -1,6 +1,7 @@
 package com.example.client.data.api
 
 import com.example.client.data.model.request.JobOnBoardingRequest
+import com.example.client.data.model.request.JobPostLicenseRequest
 import com.example.client.data.model.request.KakaoLoginRequest
 import com.example.client.data.model.request.MainOnBoardingRequest
 import com.example.client.data.model.response.LicensesGetResponse
@@ -36,7 +37,7 @@ interface ApiService {
     suspend fun searchJob(): Response<Void>
 
     @GET("jobs/posts/licenses") //사용자가 클릭한 자격증 이름으로 request
-    suspend fun getJobLicenses(): Response<Void>
+    suspend fun getJobLicense(@Body request: JobPostLicenseRequest): Response<List<JobPostResponse>>
 
     /** 자격증 리스트 소환 */
     @GET("licenses")

--- a/app/src/main/java/com/example/client/data/model/request/JobPostLicenseRequest.kt
+++ b/app/src/main/java/com/example/client/data/model/request/JobPostLicenseRequest.kt
@@ -1,0 +1,5 @@
+package com.example.client.data.model.request
+
+data class JobPostLicenseRequest (
+    val jmfldnm: String
+)

--- a/app/src/main/java/com/example/client/data/model/request/JobPostLicenseRequest.kt
+++ b/app/src/main/java/com/example/client/data/model/request/JobPostLicenseRequest.kt
@@ -1,5 +1,0 @@
-package com.example.client.data.model.request
-
-data class JobPostLicenseRequest (
-    val jmfldnm: String
-)

--- a/app/src/main/java/com/example/client/data/model/request/mypage/EditLicenseRequest.kt
+++ b/app/src/main/java/com/example/client/data/model/request/mypage/EditLicenseRequest.kt
@@ -1,0 +1,7 @@
+package com.example.client.data.model.request.mypage
+
+import com.example.client.data.model.response.LicensesGetResponse
+
+data class EditLicenseRequest (
+    val licenses: List<LicensesGetResponse>
+)

--- a/app/src/main/java/com/example/client/data/model/viewmodel/JobPostLicenseViewModel.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/JobPostLicenseViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.client.data.model.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.client.data.model.response.JobPostResponse
+import com.example.client.data.repository.JobPostLicenseRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.Response
+
+class JobPostLicenseViewModel(private val repository: JobPostLicenseRepository): ViewModel() {
+    private val _jobList = MutableStateFlow<List<JobPostResponse>>(emptyList())
+    val jobList = _jobList.asStateFlow()
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading = _isLoading.asStateFlow()
+    private val _error = MutableStateFlow<String?>(null)
+    val error = _error.asStateFlow()
+    fun getJobLicense(jmfldnm: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                val response: Response<List<JobPostResponse>> = repository.getJobLicenseList(jmfldnm)
+                if (response.isSuccessful) {
+                    _jobList.value = response.body() ?: emptyList()
+                    println("Job license list fetched successfully!")
+                    println(_jobList.value)
+                } else {
+                    _error.value = "Failed to fetch jobs: ${response.code()}"
+                    println("Failed to fetch job license list: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _error.value = e.message ?: "An unknown error occurred"
+                println("Error fetching job license list: ${e.message}")
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/client/data/model/viewmodel/JobPostLicenseViewModelFactory.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/JobPostLicenseViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.client.data.model.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.client.data.repository.JobPostLicenseRepository
+
+class JobPostLicenseViewModelFactory(private val repository: JobPostLicenseRepository): ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(JobPostLicenseViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return JobPostLicenseViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
@@ -1,0 +1,35 @@
+package com.example.client.data.model.viewmodel.mypage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.client.data.model.response.LicensesGetResponse
+import com.example.client.data.repository.mypage.EditLicenseRepository
+import com.example.client.domain.TestUserInfo
+import kotlinx.coroutines.launch
+import retrofit2.Response
+
+class EditLicenseViewModel(private val repository: EditLicenseRepository) : ViewModel() {
+
+    fun setUserLicenses(selectedLicenses: List<LicensesGetResponse>) {
+        viewModelScope.launch {
+            try {
+                val response: Response<Void> = repository.setUserLicense(selectedLicenses)
+                if (response.isSuccessful) {
+                    println("Interest fields updated successfully!")
+                    TestUserInfo.LICENSES.clear()
+                    TestUserInfo.LICENSES.addAll(selectedLicenses.map { license ->
+                        LicensesGetResponse(
+                            jmfldnm = license.jmfldnm,
+                            seriesnm = license.seriesnm,
+                            expirationDate = license.expirationDate
+                        )
+                    })
+                } else {
+                    println("Failed to update interest fields: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                println("Error updating interest fields: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
@@ -6,13 +6,24 @@ import com.example.client.data.model.response.LicensesGetResponse
 import com.example.client.data.repository.mypage.EditLicenseRepository
 import com.example.client.domain.TestUserInfo
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import retrofit2.Response
 
 class EditLicenseViewModel(private val repository: EditLicenseRepository) : ViewModel() {
     private val _selectedLicenses = MutableStateFlow<List<LicensesGetResponse>>(emptyList())
     val selectedLicenses: StateFlow<List<LicensesGetResponse>> = _selectedLicenses
+
+    fun isLicenseSelectedFlow(license: LicensesGetResponse): StateFlow<Boolean> {
+        return _selectedLicenses.map { it.contains(license) }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = false
+        )
+    }
 
     fun toggleLicencesSelection(license: LicensesGetResponse) {
         val currentList = _selectedLicenses.value.toMutableList()

--- a/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModel.kt
@@ -5,17 +5,33 @@ import androidx.lifecycle.viewModelScope
 import com.example.client.data.model.response.LicensesGetResponse
 import com.example.client.data.repository.mypage.EditLicenseRepository
 import com.example.client.domain.TestUserInfo
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import retrofit2.Response
 
 class EditLicenseViewModel(private val repository: EditLicenseRepository) : ViewModel() {
+    private val _selectedLicenses = MutableStateFlow<List<LicensesGetResponse>>(emptyList())
+    val selectedLicenses: StateFlow<List<LicensesGetResponse>> = _selectedLicenses
+
+    fun toggleLicencesSelection(license: LicensesGetResponse) {
+        val currentList = _selectedLicenses.value.toMutableList()
+        if (currentList.contains(license)) {
+            // 이미 선택된 자격증이면 제거
+            currentList.remove(license)
+        } else {
+            // 새로운 자격증이면 추가
+            currentList.add(license)
+        }
+        _selectedLicenses.value = currentList
+    }
 
     fun setUserLicenses(selectedLicenses: List<LicensesGetResponse>) {
         viewModelScope.launch {
             try {
                 val response: Response<Void> = repository.setUserLicense(selectedLicenses)
                 if (response.isSuccessful) {
-                    println("Interest fields updated successfully!")
+                    println("license fields updated successfully!")
                     TestUserInfo.LICENSES.clear()
                     TestUserInfo.LICENSES.addAll(selectedLicenses.map { license ->
                         LicensesGetResponse(
@@ -25,10 +41,10 @@ class EditLicenseViewModel(private val repository: EditLicenseRepository) : View
                         )
                     })
                 } else {
-                    println("Failed to update interest fields: ${response.code()}")
+                    println("Failed to update license fields: ${response.code()}")
                 }
             } catch (e: Exception) {
-                println("Error updating interest fields: ${e.message}")
+                println("Error updating license fields: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModelFactory.kt
+++ b/app/src/main/java/com/example/client/data/model/viewmodel/mypage/EditLicenseViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.client.data.model.viewmodel.mypage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.client.data.repository.mypage.EditLicenseRepository
+
+class EditLicenseViewModelFactory(private val repository: EditLicenseRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(EditLicenseViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return EditLicenseViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/client/data/repository/JobPostLicenseRepository.kt
+++ b/app/src/main/java/com/example/client/data/repository/JobPostLicenseRepository.kt
@@ -1,7 +1,6 @@
 package com.example.client.data.repository
 
 import com.example.client.data.api.ApiService
-import com.example.client.data.model.request.JobPostLicenseRequest
 import com.example.client.data.model.response.JobPostResponse
 import retrofit2.Response
 
@@ -9,7 +8,7 @@ class JobPostLicenseRepository(private val apiService: ApiService) {
     suspend fun getJobLicenseList(
         jmfldname: String
     ): Response<List<JobPostResponse>>{
-        val request = JobPostLicenseRequest(jmfldname)
+        val request = jmfldname
         return apiService.getJobLicense(request)
     }
 }

--- a/app/src/main/java/com/example/client/data/repository/mypage/EditLicenseRepository.kt
+++ b/app/src/main/java/com/example/client/data/repository/mypage/EditLicenseRepository.kt
@@ -1,0 +1,16 @@
+package com.example.client.data.repository.mypage
+
+import com.example.client.data.api.ApiService
+import com.example.client.data.model.request.mypage.EditInterestedRequest
+import com.example.client.data.model.request.mypage.EditLicenseRequest
+import com.example.client.data.model.response.LicensesGetResponse
+import retrofit2.Response
+
+class EditLicenseRepository(private val apiService: ApiService) {
+    suspend fun setUserLicense(
+        licenses: List<LicensesGetResponse>
+    ): Response<Void> {
+        val request = EditLicenseRequest(licenses)
+        return apiService.setUserLicenses(request)
+    }
+}

--- a/app/src/main/java/com/example/client/data/repository/mypage/JobPostLicenseRepository.kt
+++ b/app/src/main/java/com/example/client/data/repository/mypage/JobPostLicenseRepository.kt
@@ -1,0 +1,15 @@
+package com.example.client.data.repository
+
+import com.example.client.data.api.ApiService
+import com.example.client.data.model.request.JobPostLicenseRequest
+import com.example.client.data.model.response.JobPostResponse
+import retrofit2.Response
+
+class JobPostLicenseRepository(private val apiService: ApiService) {
+    suspend fun getJobLicenseList(
+        jmfldname: String
+    ): Response<List<JobPostResponse>>{
+        val request = JobPostLicenseRequest(jmfldname)
+        return apiService.getJobLicense(request)
+    }
+}

--- a/app/src/main/java/com/example/client/domain/UserInfo.kt
+++ b/app/src/main/java/com/example/client/domain/UserInfo.kt
@@ -1,5 +1,8 @@
 package com.example.client.domain
 
+import com.example.client.data.model.response.LicenseResponse
+import com.example.client.data.model.response.LicensesGetResponse
+
 object TestUserInfo {
     var TEST_USERNAME = "김영숙"
     const val TEST_PASSWORD = "admin"
@@ -10,7 +13,7 @@ object TestUserInfo {
     var EMPLOYMENT = ""
     var SEX:String?=null
     var YEAR:Int?=null
-    var LICENSES:List<String> = emptyList()
+    var LICENSES:MutableList<LicensesGetResponse> = mutableListOf()
 }
 
 //object UserInfo {

--- a/app/src/main/java/com/example/client/domain/UserInfo.kt
+++ b/app/src/main/java/com/example/client/domain/UserInfo.kt
@@ -8,9 +8,9 @@ object TestUserInfo {
     var REGION = ""
     var REBORNTEMPERATURE = 0
     var EMPLOYMENT = ""
-    var sex:String?=null
-    var year:Int?=null
-    var licenses:List<String> = emptyList()
+    var SEX:String?=null
+    var YEAR:Int?=null
+    var LICENSES:List<String> = emptyList()
 }
 
 //object UserInfo {

--- a/app/src/main/java/com/example/client/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/client/navigation/BottomNavigationBar.kt
@@ -43,8 +43,8 @@ fun BottomNavigationBar(navController: NavController) {
                     modifier = Modifier.background(color = Color.White),
                     selected = currentRoute == navItem.route,
                     onClick = {
-                        if(navItem.route.equals("JobMain")){
-                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == 0){
+                        if(navItem.route == "JobMain"){
+                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == null){
                                 navController.navigate("JobOnboarding")
                                 {
                                     popUpTo(navController.graph.findStartDestination().id) {
@@ -57,10 +57,11 @@ fun BottomNavigationBar(navController: NavController) {
                                     }
                                 }
                             }
-                        }
-                        navController.navigate(navItem.route)
-                        {
-                            popUpTo(navController.graph.findStartDestination().id) {
+                        }else{
+                            navController.navigate(navItem.route)
+                            {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                }
                             }
                         }
                     },

--- a/app/src/main/java/com/example/client/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/client/navigation/BottomNavigationBar.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.client.R
+import com.example.client.domain.TestUserInfo
 
 @Composable
 fun BottomNavigationBar(navController: NavController) {
@@ -36,12 +37,27 @@ fun BottomNavigationBar(navController: NavController) {
     ) {
         val backStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = backStackEntry?.destination?.route
-        if(!(currentRoute.equals("Login") || currentRoute.equals("MainOnboarding"))){
+        if(!(currentRoute.equals("Login") || currentRoute.equals("MainOnboarding")|| currentRoute.equals("JobOnboarding"))){
             NavBarItems.BarItems.forEach { navItem ->
                 NavigationBarItem(
                     modifier = Modifier.background(color = Color.White),
                     selected = currentRoute == navItem.route,
                     onClick = {
+                        if(navItem.route.equals("JobMain")){
+                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == 0){
+                                navController.navigate("JobOnboarding")
+                                {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                    }
+                                }
+                            }else{
+                                navController.navigate("JobMain")
+                                {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                    }
+                                }
+                            }
+                        }
                         navController.navigate(navItem.route)
                         {
                             popUpTo(navController.graph.findStartDestination().id) {

--- a/app/src/main/java/com/example/client/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/example/client/navigation/NavRoutes.kt
@@ -9,5 +9,6 @@ sealed class NavRoutes(val route: String) {
     object MyPageInterest : NavRoutes("MyPageInterest")
     object MyPageRegion : NavRoutes("MyPageRegion")
     object MyPageProfile : NavRoutes("MyPageProfile")
+    object MyPageLicense : NavRoutes("MyPageLicense")
     object JobOnboarding : NavRoutes("JobOnboarding")
 }

--- a/app/src/main/java/com/example/client/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/example/client/navigation/NavigationHost.kt
@@ -91,6 +91,7 @@ fun NavigationHost(
 
         composable(NavRoutes.MyPageLicense.route) {
             EditLicenseScreen(
+                sharedViewModel = viewModels.sharedCertificationViewModel,
                 editLicenseViewModel = viewModels.editLicenseViewModel,
                 navController = navController
             )

--- a/app/src/main/java/com/example/client/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/example/client/navigation/NavigationHost.kt
@@ -12,6 +12,7 @@ import com.example.client.screen.MainScreen
 import com.example.client.screen.MainOnboardingScreen
 import com.example.client.screen.MyPageScreen
 import com.example.client.screen.mypage.EditInterestedFieldScreen
+import com.example.client.screen.mypage.EditLicenseScreen
 import com.example.client.screen.mypage.EditProfileScreen
 import com.example.client.screen.mypage.EditRegionScreen
 
@@ -88,5 +89,11 @@ fun NavigationHost(
             )
         }
 
+        composable(NavRoutes.MyPageLicense.route) {
+            EditLicenseScreen(
+                editLicenseViewModel = viewModels.editLicenseViewModel,
+                navController = navController
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/client/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/example/client/navigation/NavigationHost.kt
@@ -47,6 +47,7 @@ fun NavigationHost(
         composable(NavRoutes.JobMain.route) {
             JobMainScreen(
                 jobPostViewModel = viewModels.jobPostViewModel,
+                jobPostLicenseViewModel = viewModels.jobPostLicenseViewModel,
                 navController = navController
             )
         }

--- a/app/src/main/java/com/example/client/screen/JobMainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobMainScreen.kt
@@ -56,10 +56,12 @@ import com.example.client.component.all.TabLayoutComponent
 import com.example.client.data.model.viewmodel.JobPostViewModel
 import com.example.client.domain.TestUserInfo
 import androidx.compose.ui.platform.LocalContext
+import com.example.client.data.model.viewmodel.JobPostLicenseViewModel
 
 @Composable
 fun JobMainScreen(
     jobPostViewModel: JobPostViewModel,
+    jobPostLicenseViewModel: JobPostLicenseViewModel,
     navController: NavController
 ) {
     // Context를 상위 레벨에서 가져옴

--- a/app/src/main/java/com/example/client/screen/JobMainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobMainScreen.kt
@@ -56,7 +56,11 @@ import com.example.client.component.all.TabLayoutComponent
 import com.example.client.data.model.viewmodel.JobPostViewModel
 import com.example.client.domain.TestUserInfo
 import androidx.compose.ui.platform.LocalContext
+import com.example.client.component.mypage.CertificateItemComponent
+import com.example.client.data.model.response.LicenseResponse
+import com.example.client.data.model.response.LicensesGetResponse
 import com.example.client.data.model.viewmodel.JobPostLicenseViewModel
+import java.util.Date
 
 @Composable
 fun JobMainScreen(
@@ -275,19 +279,13 @@ fun JobMainScreen(
                                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                                     verticalArrangement = Arrangement.spacedBy(8.dp)
                                 ) {
-                                    val certList = listOf(
-                                        Triple("한국고용정보원", "고용서비스", "25.07.15"),
-                                        Triple("한국산업인력공단", "지게차운전", "25.08.20"),
-                                        Triple("대한상공회의소", "컴퓨터활용능력", "25.09.10"),
-                                        Triple("한국고용정보원", "직업상담사", "25.10.15")
-                                        // ... 더 많은 데이터
-                                    )
-
-                                    items(certList) { (dept, name, date) ->
+                                    items(TestUserInfo.LICENSES) { license ->
                                         CertificateButtonComponent(
-                                            certificateDepartment = dept,
-                                            certificateName = name,
-                                            date = date,
+                                            license = LicensesGetResponse(
+                                                jmfldnm = license.jmfldnm,
+                                                seriesnm = license.seriesnm,
+                                                expirationDate = license.expirationDate
+                                            ),
                                             onClick = { /* 자격증 상세 정보로 이동 */ }
                                         )
                                     }

--- a/app/src/main/java/com/example/client/screen/JobMainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobMainScreen.kt
@@ -178,6 +178,10 @@ fun JobMainScreen(
                                             buttonText = TestUserInfo.REGION,
                                             onClick = {}
                                         )
+                                        KeywordButtonComponent(
+                                            buttonText = "${TestUserInfo.YEAR} / ${TestUserInfo.SEX}",
+                                            onClick = {}
+                                        )
                                     }
                                     items(TestUserInfo.INTEREST) { interest ->
                                         Spacer(modifier = Modifier.size(10.dp))

--- a/app/src/main/java/com/example/client/screen/JobMainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobMainScreen.kt
@@ -185,6 +185,7 @@ fun JobMainScreen(
                                             buttonText = TestUserInfo.REGION,
                                             onClick = {}
                                         )
+                                        Spacer(modifier = Modifier.size(10.dp))
                                         KeywordButtonComponent(
                                             buttonText = "${TestUserInfo.YEAR} / ${TestUserInfo.SEX}",
                                             onClick = {}

--- a/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
@@ -526,9 +526,9 @@ fun JobOnBoardingScreen(
                             val year = selectBirth?.toInt()
                             if (sex != null && year != null) {
                                 viewModel.submitJobOnboarding(sex, year)
-                                TestUserInfo.sex=sex
-                                TestUserInfo.year=year
-                                TestUserInfo.licenses=selectedLicenses.map { it.jmfldnm }
+                                TestUserInfo.SEX=sex
+                                TestUserInfo.YEAR=year
+                                TestUserInfo.LICENSES=selectedLicenses.map { it.jmfldnm }
                                 navController.navigate(NavRoutes.JobMain.route) {
                                     popUpTo(NavRoutes.JobOnboarding.route) { inclusive = true }
                                 }

--- a/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
@@ -452,9 +452,7 @@ fun JobOnBoardingScreen(
                                 buttonText = if (selectedLicensesCount == 0) "추가하기" else "${selectedLicensesCount}개 추가완료하기",
                                 buttonColorType = if (selectedLicensesCount == 0) ButtonColorEnum.LightGreen else ButtonColorEnum.Green,
                                 onClick = {
-                                    if (selectedLicensesCount != 0) {
-                                        currentQuestionIndex++
-                                    }
+                                    currentQuestionIndex++
                                 },
                                 modifier = Modifier
                                     .align(Alignment.BottomCenter)

--- a/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
@@ -524,6 +524,7 @@ fun JobOnBoardingScreen(
                         onClick = {
                             val sex = selectGender
                             val year = selectBirth?.toInt()
+                            println(sex + ":" + year.toString())
                             if (sex != null && year != null) {
                                 viewModel.submitJobOnboarding(sex, year)
                                 TestUserInfo.SEX=sex

--- a/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
+++ b/app/src/main/java/com/example/client/screen/JobOnBoardingScreen.kt
@@ -47,6 +47,7 @@ import com.example.client.component.all.ButtonComponent
 import com.example.client.component.all.CertificateComponent
 import com.example.client.component.all.DropDownMenuComponent
 import com.example.client.component.onboarding.PageIndexComponent
+import com.example.client.data.model.response.LicensesGetResponse
 import com.example.client.data.model.viewmodel.JobOnBoardingViewModel
 import com.example.client.data.model.viewmodel.SharedCertificationViewModel
 import com.example.client.domain.TestUserInfo
@@ -529,7 +530,14 @@ fun JobOnBoardingScreen(
                                 viewModel.submitJobOnboarding(sex, year)
                                 TestUserInfo.SEX=sex
                                 TestUserInfo.YEAR=year
-                                TestUserInfo.LICENSES=selectedLicenses.map { it.jmfldnm }
+                                TestUserInfo.LICENSES.clear()
+                                TestUserInfo.LICENSES.addAll(selectedLicenses.map { license ->
+                                    LicensesGetResponse(
+                                        jmfldnm = license.jmfldnm,
+                                        seriesnm = license.seriesnm,
+                                        expirationDate = license.expirationDate
+                                    )
+                                })
                                 navController.navigate(NavRoutes.JobMain.route) {
                                     popUpTo(NavRoutes.JobOnboarding.route) { inclusive = true }
                                 }

--- a/app/src/main/java/com/example/client/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/MainScreen.kt
@@ -105,13 +105,13 @@ fun MainScreen(navController: NavController) {
                         .height(100.dp)
                         .clip(CircleShape)
                         .clickable { navController.navigate("MyPage") },
-                    error = painterResource(id = R.drawable.btn_editprofile),
-                    placeholder = painterResource(id = R.drawable.btn_editprofile)
+                    error = painterResource(id = R.drawable.icon_rebornlogo),
+                    placeholder = painterResource(id = R.drawable.icon_rebornlogo)
                 )
             } else {
                 Image(
                     painter = painterResource(id = R.drawable.icon_rebornlogo),
-                    contentDescription = "Btn_editprofile",
+                    contentDescription = "기본 이미지",
                     modifier = Modifier
                         .width(129.dp)
                         .height(83.dp)
@@ -144,7 +144,7 @@ fun MainScreen(navController: NavController) {
                     modifier = Modifier
                         .padding(top = 20.dp, start = 5.dp)
                         .clickable {
-                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == 0){
+                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == null){
                                 navController.navigate("JobOnboarding")
                             } else {
                                 navController.navigate("JobMain")

--- a/app/src/main/java/com/example/client/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/client/screen/MainScreen.kt
@@ -144,7 +144,7 @@ fun MainScreen(navController: NavController) {
                     modifier = Modifier
                         .padding(top = 20.dp, start = 5.dp)
                         .clickable {
-                            if (TestUserInfo.sex.isNullOrEmpty()) {
+                            if(TestUserInfo.SEX.isNullOrEmpty() || TestUserInfo.YEAR == 0){
                                 navController.navigate("JobOnboarding")
                             } else {
                                 navController.navigate("JobMain")

--- a/app/src/main/java/com/example/client/screen/MypageScreen.kt
+++ b/app/src/main/java/com/example/client/screen/MypageScreen.kt
@@ -253,6 +253,9 @@ fun MyPageScreen(
                     painter = painterResource(id = R.drawable.rounded_edit_square_24),
                     contentDescription = null,
                     modifier = Modifier.padding(top = 20.dp, start = 300.dp)
+                        .clickable {
+                            navController.navigate("MyPageLicense")
+                        }
                 )
                 Text(
                     text = "나의 자격증",

--- a/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
@@ -1,13 +1,176 @@
 package com.example.client.screen.mypage
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.client.R
+import com.example.client.component.all.ButtonColorEnum
+import com.example.client.component.all.ButtonComponent
+import com.example.client.component.all.CertificateComponent
+import com.example.client.data.model.viewmodel.SharedCertificationViewModel
 import com.example.client.data.model.viewmodel.mypage.EditLicenseViewModel
+import com.example.client.domain.TestUserInfo
 
 @Composable
 fun EditLicenseScreen(
+    sharedViewModel: SharedCertificationViewModel,
     editLicenseViewModel: EditLicenseViewModel,
     navController: NavController
 ){
+    var nickname by remember { mutableStateOf<String?>(null) }
 
+
+    val licensesState by sharedViewModel.licensesState.collectAsState()
+    val isLoading by sharedViewModel.isLoading.collectAsState()
+    val errorMessage by sharedViewModel.errorMessage.collectAsState()
+
+    val selectedLicenses by editLicenseViewModel.selectedLicenses.collectAsState()
+    val selectedLicensesCount = selectedLicenses.size
+
+    LaunchedEffect(Unit) {
+        nickname = TestUserInfo.TEST_USERNAME
+        sharedViewModel.fetchLicenses()
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color(0xFFFFFEF4))
+    ) {
+        item {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(color = Color(0xFFFFFBDC)),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Row(
+                    modifier = Modifier.padding(top = 30.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "자격증 수정",
+                        style = TextStyle(
+                            fontSize = 24.sp,
+                            lineHeight = 33.6.sp,
+                            fontFamily = FontFamily(Font(R.font.pretendardextrabold)),
+                            color = Color(0xFF000000),
+                            textAlign = TextAlign.Center,
+                        )
+                    )
+                }
+            }
+        }
+
+        item {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 50.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    when {
+                        isLoading -> {
+                            CircularProgressIndicator(
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        }
+
+                        errorMessage != null -> {
+                            Text(
+                                text = errorMessage ?: "Unknown Error",
+                                color = Color.Red,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        }
+
+                        licensesState.isNotEmpty() -> {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(400.dp)
+                            ) {
+                                LazyColumn(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                ) {
+                                    items(licensesState) { license ->
+                                        CertificateComponent(
+                                            type = license.seriesnm,
+                                            name = license.jmfldnm,
+                                            date = license.expirationDate ?: "2024-12-05",
+                                            isSelected = if(TestUserInfo.LICENSES.contains(license)) true else false,
+                                            onItemSelected = { selectedLicense ->
+                                                editLicenseViewModel.toggleLicencesSelection(selectedLicense)
+                                            },
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .padding(horizontal = 39.dp),
+                                        )
+                                        Spacer(modifier = Modifier.height(25.dp))
+                                    }
+                                }
+                            }
+                        }
+
+                        else -> {
+                            Text(
+                                text = "No certificates available",
+                                modifier = Modifier.align(Alignment.Center),
+                                color = Color.Gray
+                            )
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(20.dp))
+                ButtonComponent(
+                    buttonText = if (selectedLicensesCount == 0) "설정하기" else "${selectedLicensesCount}개 추가완료하기",
+                    buttonColorType = if (selectedLicensesCount == 0) ButtonColorEnum.LightGreen else ButtonColorEnum.Green,
+                    onClick = {
+                        editLicenseViewModel.setUserLicenses(selectedLicenses)
+                        navController.navigate("MyPage")
+                    },
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
@@ -53,7 +53,7 @@ fun EditLicenseScreen(
     val isLoading by sharedViewModel.isLoading.collectAsState()
     val errorMessage by sharedViewModel.errorMessage.collectAsState()
 
-    val selectedLicenses by editLicenseViewModel.selectedLicenses.collectAsState()
+    val selectedLicenses by editLicenseViewModel.selectedLicenses.collectAsState(TestUserInfo.LICENSES)
     val selectedLicensesCount = selectedLicenses.size
 
     LaunchedEffect(Unit) {
@@ -127,18 +127,21 @@ fun EditLicenseScreen(
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(400.dp)
+                                    .height(520.dp)
                             ) {
                                 LazyColumn(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                 ) {
                                     items(licensesState) { license ->
+                                        val isSelected by editLicenseViewModel.isLicenseSelectedFlow(
+                                            license
+                                        ).collectAsState()
                                         CertificateComponent(
                                             type = license.seriesnm,
                                             name = license.jmfldnm,
                                             date = license.expirationDate ?: "2024-12-05",
-                                            isSelected = if(TestUserInfo.LICENSES.contains(license)) true else false,
+                                            isSelected = isSelected,
                                             onItemSelected = { selectedLicense ->
                                                 editLicenseViewModel.toggleLicencesSelection(selectedLicense)
                                             },

--- a/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditLicenseScreen.kt
@@ -1,0 +1,13 @@
+package com.example.client.screen.mypage
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.example.client.data.model.viewmodel.mypage.EditLicenseViewModel
+
+@Composable
+fun EditLicenseScreen(
+    editLicenseViewModel: EditLicenseViewModel,
+    navController: NavController
+){
+
+}

--- a/app/src/main/java/com/example/client/screen/mypage/EditLicensesScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditLicensesScreen.kt
@@ -1,2 +1,0 @@
-package com.example.client.screen.mypage
-

--- a/app/src/main/java/com/example/client/screen/mypage/EditProfileScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditProfileScreen.kt
@@ -174,13 +174,13 @@ fun EditProfileScreen(
                     onClick = {
                         selectedImageUri?.let { uri ->
                             editProfileViewModel.setUserProfile(
-                                nickName = editNickname,
-                                profileImg = uri.toString(),  // URI 문자열로 전달
+                                nickName = editNickname.ifEmpty { nickname.toString() },
+                                profileImg = uri.toString(),
                                 employmentStatus = editEmploymentStatus
                             )
                         } ?: run {
                             editProfileViewModel.setUserProfile(
-                                nickName = editNickname,
+                                nickName = editNickname.ifEmpty { nickname.toString() },
                                 profileImg = TestUserInfo.USERIMG,
                                 employmentStatus = editEmploymentStatus
                             )

--- a/app/src/main/java/com/example/client/screen/mypage/EditProfileScreen.kt
+++ b/app/src/main/java/com/example/client/screen/mypage/EditProfileScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## 🐣Title

[Feature/license] 자격증 마이페이지 수정, 자격증 기반 일자리 기능 구현

<br/>

## 🐣Part

Client

<br/>

## 🐣Key Changes


<br/>

## 🐣Screenshot
<img width="289" alt="image" src="https://github.com/user-attachments/assets/b9485e5a-6351-42c5-bc30-5a8c3fd8a6ae">

<img width="281" alt="image" src="https://github.com/user-attachments/assets/ad223fb8-6154-487e-813f-6968811117bc">

<img width="290" alt="image" src="https://github.com/user-attachments/assets/c3170753-20da-47f5-a671-fcf5ed6c95b0">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/4d31cd70-93f3-483f-8994-3a05175a8428">

<br/>

## 🐣To Reviewer

1. 자격증 컴포넌트 클릭 왔다갔다 하는 거 수정해야 함..
2. 메인에 버튼 그림자 유무 다 달라서 이거 맞춰서 파일 다시 넣어야 할듯(ui 손보는 시간 가져볼게요..따로 pr 올리겠음)
3. 로그인한 유저 정보 있으면 로그인도 안 띄울까 고민?..

<br/>

## 🐣Next

1. 알람........
2. 메인에 그 추천 정보 띄우는 거 일자리 아무거나 하나 골라서 띄울까 고민!

<br/>

## 🐣Issue

#25 , #10 

<br/>
